### PR TITLE
add endpoints for nomenklatura attributes

### DIFF
--- a/api/v1/places/__init__.py
+++ b/api/v1/places/__init__.py
@@ -1,1 +1,2 @@
 from reconcile import *
+from attributes import *

--- a/api/v1/places/attributes.py
+++ b/api/v1/places/attributes.py
@@ -14,6 +14,7 @@ from ..helpers import create_response
 from .. import exceptions
 
 
+# TODO move to config
 NOMENKLATURA_URL = "http://nomenklatura.uniceflabs.org/api/2/entities"
 NOMENKLATURA_API_KEY = "e5d2155a-d0e5-477f-97ba-762ed14af407"
 NOMENKLATURA_HEADERS = {"Authorization": "e5d2155a-d0e5-477f-97ba-762ed14af407"}
@@ -32,13 +33,10 @@ def nomenklatura_retrieve_entity_attributes():
         data = request.values
 
     if data:
-        print data
-
         if 'entity' not in data:
             raise exceptions.APIError(message='Missing field: entity',
                                       field='entity',
                                       resource=rule_link(request.url_rule))
-
 
         payload = {'format': 'json'}
         payload['api_key'] = NOMENKLATURA_API_KEY
@@ -59,7 +57,6 @@ def nomenklatura_retrieve_entity_attributes():
                                         query: None,
                                         '_links': {'self':
                                                     rule_link(request.url_rule)}})
-
 
         return create_response({'entity': results,
                                 '_links': {'self':

--- a/api/v1/places/attributes.py
+++ b/api/v1/places/attributes.py
@@ -46,7 +46,6 @@ def nomenklatura_retrieve_entity_attributes():
                               json=payload)
         results = result.json()
 
-        print results
         if 'attribute' in data:
             query = data['attribute']
             if (results.get('attributes') is not None) and (query in results['attributes'].keys()):
@@ -93,7 +92,6 @@ def nomenklatura_update_entity_attributes():
         result = requests.get(_url_for_entity(data['entity']),
                               json=payload)
         results = result.json()
-        print results
 
         # update endpoint requires name
         payload['name'] = results['name']

--- a/api/v1/places/attributes.py
+++ b/api/v1/places/attributes.py
@@ -67,7 +67,7 @@ def nomenklatura_retrieve_entity_attributes():
 
     abort(400)
 
-@api.route('/nomenklatura/entity/update', methods=['POST',])
+@api.route('/nomenklatura/entity', methods=['POST',])
 @limit(max_requests=1000, period=60, by="ip")
 def nomenklatura_update_entity_attributes():
     if request.json is not None:

--- a/api/v1/places/attributes.py
+++ b/api/v1/places/attributes.py
@@ -32,6 +32,7 @@ def nomenklatura_retrieve_entity_attributes():
         data = request.values
 
     if data:
+        print data
 
         if 'entity' not in data:
             raise exceptions.APIError(message='Missing field: entity',
@@ -75,7 +76,6 @@ def nomenklatura_update_entity_attributes():
         data = request.values
 
     if data:
-
         if 'entity' not in data:
             raise exceptions.APIError(message='Missing field: entity',
                                       field='entity',
@@ -85,6 +85,16 @@ def nomenklatura_update_entity_attributes():
                                       field='attributes',
                                       resource=rule_link(request.url_rule))
 
+        # rapidpro doesnt send json post data. instead we'll have a form field
+        # with a json string inside rather than a dict from request.json
+        if not isinstance(data['attributes'], dict):
+            try:
+                # request.values is a CombinedMultiDict, so convert to dict
+                data = data.to_dict()
+                data['attributes'] = json.loads(data['attributes'])
+            except json.JSONDecodeError:
+                # we didn't get json or anything json-like, so abort
+                abort(400)
 
         payload = {'format': 'json'}
         payload['api_key'] = NOMENKLATURA_API_KEY

--- a/api/v1/places/attributes.py
+++ b/api/v1/places/attributes.py
@@ -1,0 +1,117 @@
+import datetime
+import json
+
+from ..api import api  # Circular, but safe
+
+from flask import request
+from flask import abort
+from flask import g
+import requests
+
+from ..decorators import limit
+from ..helpers import rule_link
+from ..helpers import create_response
+from .. import exceptions
+
+
+NOMENKLATURA_URL = "http://nomenklatura.uniceflabs.org/api/2/entities"
+NOMENKLATURA_API_KEY = "e5d2155a-d0e5-477f-97ba-762ed14af407"
+NOMENKLATURA_HEADERS = {"Authorization": "e5d2155a-d0e5-477f-97ba-762ed14af407"}
+
+def _url_for_entity(entity_id):
+    return NOMENKLATURA_URL + '/' + entity_id
+
+
+@api.route('/nomenklatura/entity', methods=['GET',])
+@limit(max_requests=1000, period=60, by="ip")
+def nomenklatura_retrieve_entity_attributes():
+
+    if request.json is not None:
+        data = request.json
+    else:
+        data = request.values
+
+    if data:
+
+        if 'entity' not in data:
+            raise exceptions.APIError(message='Missing field: entity',
+                                      field='entity',
+                                      resource=rule_link(request.url_rule))
+
+
+        payload = {'format': 'json'}
+        payload['api_key'] = NOMENKLATURA_API_KEY
+
+        result = requests.get(_url_for_entity(data['entity']),
+                              json=payload)
+        results = result.json()
+
+        print results
+        if 'attribute' in data:
+            query = data['attribute']
+            if (results.get('attributes') is not None) and (query in results['attributes'].keys()):
+                return create_response({'entity': results,
+                                        query: results['attributes'][query],
+                                        '_links': {'self':
+                                                    rule_link(request.url_rule)}})
+            else:
+                return create_response({'entity': results,
+                                        query: None,
+                                        '_links': {'self':
+                                                    rule_link(request.url_rule)}})
+
+
+        return create_response({'entity': results,
+                                '_links': {'self':
+                                            rule_link(request.url_rule)}})
+
+    abort(400)
+
+@api.route('/nomenklatura/entity/update', methods=['POST',])
+@limit(max_requests=1000, period=60, by="ip")
+def nomenklatura_update_entity_attributes():
+    if request.json is not None:
+        data = request.json
+    else:
+        data = request.values
+
+    if data:
+
+        if 'entity' not in data:
+            raise exceptions.APIError(message='Missing field: entity',
+                                      field='entity',
+                                      resource=rule_link(request.url_rule))
+        if 'attributes' not in data:
+            raise exceptions.APIError(message='Missing field: attributes',
+                                      field='attributes',
+                                      resource=rule_link(request.url_rule))
+
+
+        payload = {'format': 'json'}
+        payload['api_key'] = NOMENKLATURA_API_KEY
+
+        result = requests.get(_url_for_entity(data['entity']),
+                              json=payload)
+        results = result.json()
+        print results
+
+        # update endpoint requires name
+        payload['name'] = results['name']
+        updated_attributes = results['attributes']
+        updated_attributes.update(data['attributes'])
+
+        # attribute values for nomenklatura must be strings (no ints!)
+        # as nomenklatura uses postgres' hstore to store attribute kv pairs
+        # TODO this smells dodgy
+        payload['attributes'] = {str(k): str(v) for k,v in updated_attributes.items()}
+
+        result = requests.post(_url_for_entity(data['entity']),
+                               headers=NOMENKLATURA_HEADERS,
+                               json=payload)
+
+        # TODO pass on a better error message from nomenklatura if non200
+        if result.status_code == requests.codes.ok:
+            return create_response({'entity': result.json(),
+                                    '_links': {'self':
+                                                rule_link(request.url_rule)}})
+    abort(400)


### PR DESCRIPTION
store and retrieve arbitrary attributes on nomenklatura entities
@xkmato can u pls review?

1) hit nomenklatura API directly to lookup entity id with an entity name
http://nomenklatura.uniceflabs.org/api/2/datasets/nepal-districts/find?name=taplejung

2) get request (to /api/v1/nomenklatura/entity/update) with entity id to fetch attributes, optionally pass an attribute name to get that back in the top level of the json response
/api/v1/nomenklatura/entity

3) post request (to /api/v1/nomenklatura/entity/update) with entity id and key value pair(s) of attributes
this fetches current attributes, updates with caller's attributes, and then saves
/api/v1/nomenklatura/entity/update
